### PR TITLE
Add the last missing sequences

### DIFF
--- a/components/BMU.sv
+++ b/components/BMU.sv
@@ -43,6 +43,10 @@ module BMU (
     logic [31:0] result_next;
     logic error_next;
     
+    // Previous result storage for valid_in behavior
+    logic [31:0] previous_result;
+    logic previous_error;
+    
     // Overflow detection for addition
     logic add_overflow;
     logic [32:0] add_result_extended; // Extended for overflow detection
@@ -75,10 +79,10 @@ module BMU (
         add_overflow = 1'b0;
         add_result_extended = 33'h0;
         
-        // Default: no operation
+        // When valid_in is disabled, return previous result
         if (!valid_in) begin
-            result_next = 32'h0;
-            error_next = 1'b0;
+            result_next = previous_result;
+            error_next = previous_error;
         end
         // Check if only one operation signal is active
         // else if (!is_single_op_active()) begin
@@ -239,10 +243,18 @@ module BMU (
         if (!rst_l) begin
             result_ff <= 32'h0;
             error <= 1'b0;
+            previous_result <= 32'h0;
+            previous_error <= 1'b0;
             // $display("[%0t] BMU: Reset asserted - result_ff <= 0, error <= 0", $time);
         end else begin
             result_ff <= result_next;
             error <= error_next;
+            
+            // Store previous result when valid_in is active
+            if (valid_in) begin
+                previous_result <= result_next;
+                previous_error <= error_next;
+            end
         end
     end
 

--- a/components/bmu_pkg.sv
+++ b/components/bmu_pkg.sv
@@ -26,6 +26,7 @@ package bmu_pkg;
   `include "../sequences/bmu_sra_sequence.sv"
   `include "../sequences/bmu_xor_sequence.sv"
   `include "../sequences/bmu_errors_sequence.sv"
+  `include "../sequences/bmu_valid_in_sequence.sv"
 
 
   // Include components (they depend on sequence_item and sequences)
@@ -56,6 +57,7 @@ package bmu_pkg;
   `include "../tests/bmu_sra_test.sv"
   `include "../tests/bmu_xor_test.sv"
   `include "../tests/bmu_errors_test.sv"
+  `include "../tests/bmu_valid_in_test.sv"
 
   
 endpackage

--- a/components/bmu_scoreboard.sv
+++ b/components/bmu_scoreboard.sv
@@ -135,10 +135,9 @@ task run_phase(uvm_phase phase);
     active_msg = get_active_signals(packet);
 
     // detailed info log
-    `uvm_info("Scoreboard", $sformatf("Validating packet with inputs: a_in=%0h, b_in=%0h, ap=%p, valid_in=%0b, csr_ren_in=%0b, csr_rddata_in=%0h, scan_mode=%0b, rst_l=%0b || Active signals: %s || Outputs: result_ff=%0h, error=%0b", 
-              packet.a_in, packet.b_in, packet.ap, packet.valid_in, packet.csr_ren_in, packet.csr_rddata_in, packet.scan_mode, packet.rst_l,
-              packet.result_ff, packet.error,
-              active_msg), UVM_HIGH);
+    `uvm_info("Scoreboard", $sformatf("Validating packet with inputs: a_in=%0h, b_in=%0h, valid_in=%0b, csr_ren_in=%0b, csr_rddata_in=%0h, scan_mode=%0b, rst_l=%0b || Active signals: %s || Outputs: result_ff=%0h, error=%0b", 
+              packet.a_in, packet.b_in, packet.valid_in, packet.csr_ren_in, packet.csr_rddata_in, packet.scan_mode, packet.rst_l,
+               active_msg, packet.result_ff, packet.error), UVM_HIGH);
 
     // less detailed info log
     `uvm_info("Scoreboard", $sformatf("Validating packet with Inputs: a_in=%0h, b_in=%0h || Active signals: %s || Outputs: result_ff=%0h, error=%0b", 

--- a/sequences/bmu_valid_in_sequence.sv
+++ b/sequences/bmu_valid_in_sequence.sv
@@ -1,0 +1,90 @@
+class bmu_valid_in_sequence extends uvm_sequence #(bmu_sequence_item);
+
+`uvm_object_utils(bmu_valid_in_sequence)
+
+function new(string name = "bmu_valid_in_sequence");
+  super.new(name);
+endfunction: new
+
+task body();
+    bmu_sequence_item req;
+    req = bmu_sequence_item::type_id::create("req");
+      
+    // ==================== Valid In Control Testing ===================
+    `uvm_info(get_type_name(), "[Valid In Test 1] Perform ADD operation - valid_in is enabled", UVM_LOW);
+    
+    // First, perform a normal ADD operation
+    start_item(req);
+    void'(req.randomize() with {
+        rst_l == 1;
+        scan_mode == 0;
+        valid_in == 1;
+        csr_ren_in == 0;
+        a_in == 32'h12345678;
+        b_in == 32'h87654321;
+    });
+    req.ap = 0;
+    req.ap.add = 1;
+    finish_item(req);
+    
+    
+    // Now disable valid_in - the output should go to zero
+    `uvm_info(get_type_name(), "[Valid In Test 2] Disable valid_in", UVM_LOW);
+    start_item(req);
+    void'(req.randomize() with {
+        rst_l == 1;
+        scan_mode == 0;
+        valid_in == 0;  // DISABLE valid_in
+        csr_ren_in == 0;
+        a_in == 32'hFFFFFFFF;  // Different inputs
+        b_in == 32'hFFFFFFFF;  // Different inputs
+    });
+    req.ap = 0;
+    req.ap.add = 1;  // Operation signals still active
+    finish_item(req);
+    
+    `uvm_info(get_type_name(), "[Valid In Test 3] Re-enable valid_in with new operation", UVM_LOW);
+    
+    // Re-enable valid_in with a new operation (AND)
+    start_item(req);
+    void'(req.randomize() with {
+        rst_l == 1;
+        scan_mode == 0;
+        valid_in == 1;  // RE-ENABLE valid_in
+        csr_ren_in == 0;
+        a_in == 32'h55555555;
+        b_in == 32'h55555555;
+    });
+    req.ap = 0;
+    req.ap.land = 1;  // AND operation
+    finish_item(req);
+    
+    
+    // Test multiple cycles with valid_in disabled
+    `uvm_info(get_type_name(), "[Valid In Test 4] Multiple cycles with valid_in disabled", UVM_LOW);
+    repeat(3) begin
+        start_item(req);
+        void'(req.randomize() with {
+            rst_l == 1;
+            scan_mode == 0;
+            valid_in == 0;  // Keep valid_in disabled
+            csr_ren_in == 0;
+        });
+        req.ap = 0;  // No operations active
+        finish_item(req);
+    end
+
+
+    // Add idle cycles
+    repeat(2) begin
+        start_item(req);
+        req.rst_l = 1;
+        req.scan_mode = 0;
+        req.valid_in = 0;  // No valid transaction - idle cycle
+        req.csr_ren_in = 0;
+        req.ap = 0;  // No operations active
+        finish_item(req);
+    end
+    
+endtask
+endclass

--- a/tests/bmu_regression_test.sv
+++ b/tests/bmu_regression_test.sv
@@ -21,6 +21,7 @@ bmu_sra_sequence sra_sequence;
 bmu_xor_sequence xor_sequence;
 bmu_reset_sequence reset_seq;
 bmu_errors_sequence errors_sequence;
+bmu_valid_in_sequence valid_in_sequence;
 
 function new(string name,uvm_component parent);
     super.new(name,parent);
@@ -51,6 +52,7 @@ task run_phase(uvm_phase phase);
     xor_sequence = bmu_xor_sequence::type_id::create("bmu_xor_sequence");
     reset_seq = bmu_reset_sequence::type_id::create("reset_seq");
     errors_sequence = bmu_errors_sequence::type_id::create("bmu_errors_sequence");
+    valid_in_sequence = bmu_valid_in_sequence::type_id::create("bmu_valid_in_sequence");
 
     reset_seq.start(env.agent.sequencer);
     // # 10;
@@ -85,6 +87,8 @@ task run_phase(uvm_phase phase);
     sra_sequence.start(env.agent.sequencer);
     // # 10;
     xor_sequence.start(env.agent.sequencer);
+    // # 10;
+    valid_in_sequence.start(env.agent.sequencer);
     // # 10;
     errors_sequence.start(env.agent.sequencer);
 

--- a/tests/bmu_valid_in_test.sv
+++ b/tests/bmu_valid_in_test.sv
@@ -1,0 +1,26 @@
+class bmu_valid_in_test extends uvm_test;
+`uvm_component_utils(bmu_valid_in_test)
+
+bmu_environment env;
+bmu_valid_in_sequence bmu_sequence;
+bmu_reset_sequence reset_seq;
+
+function new(string name,uvm_component parent);
+    super.new(name,parent);
+endfunction
+
+function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    env = bmu_environment::type_id::create("environment",this);
+endfunction
+
+task run_phase(uvm_phase phase);
+    phase.raise_objection(this);
+    bmu_sequence = bmu_valid_in_sequence::type_id::create("bmu_valid_in_sequence");
+    reset_seq = bmu_reset_sequence::type_id::create("reset_seq");
+    reset_seq.start(env.agent.sequencer);
+    bmu_sequence.start(env.agent.sequencer);
+    phase.drop_objection(this);
+    `uvm_info(get_type_name, "========= End of Valid In Test =========", UVM_LOW);
+endtask
+endclass


### PR DESCRIPTION
This pull request enhances the BMU's handling of the `valid_in` signal to ensure that, when `valid_in` is low, the module outputs the previous result instead of defaulting to zero. The update includes RTL changes, reference model alignment, and new UVM test infrastructure to thoroughly verify this behavior.

**BMU RTL and Reference Model Updates:**

* The BMU module now stores and returns the previous result and error when `valid_in` is deasserted, instead of resetting outputs to zero. This is achieved by adding `previous_result` and `previous_error` registers and updating them only when `valid_in` is high. (`components/BMU.sv` [[1]](diffhunk://#diff-b73107c3b343aa0ae96dc9543ffbe10720eee57a39e4b8de6facbb06772c88a4R46-R49) [[2]](diffhunk://#diff-b73107c3b343aa0ae96dc9543ffbe10720eee57a39e4b8de6facbb06772c88a4L78-R85) [[3]](diffhunk://#diff-b73107c3b343aa0ae96dc9543ffbe10720eee57a39e4b8de6facbb06772c88a4R246-R257)
* The `bmu_reference_model` is updated to mimic this behavior, maintaining and returning the previous result and error when `valid_in` is low. All relevant operation paths now update these previous values accordingly. (`components/bmu_reference_model.sv` [[1]](diffhunk://#diff-bcd9e3b5cd861ceb06d09dacf75f1a6488a541400c6ab9f8e71fa67b0a9f8666R7-R10) [[2]](diffhunk://#diff-bcd9e3b5cd861ceb06d09dacf75f1a6488a541400c6ab9f8e71fa67b0a9f8666L110-R127) [[3]](diffhunk://#diff-bcd9e3b5cd861ceb06d09dacf75f1a6488a541400c6ab9f8e71fa67b0a9f8666R139-R148) [[4]](diffhunk://#diff-bcd9e3b5cd861ceb06d09dacf75f1a6488a541400c6ab9f8e71fa67b0a9f8666R157-R158) [[5]](diffhunk://#diff-bcd9e3b5cd861ceb06d09dacf75f1a6488a541400c6ab9f8e71fa67b0a9f8666R168-R176) [[6]](diffhunk://#diff-bcd9e3b5cd861ceb06d09dacf75f1a6488a541400c6ab9f8e71fa67b0a9f8666R189-R217) [[7]](diffhunk://#diff-bcd9e3b5cd861ceb06d09dacf75f1a6488a541400c6ab9f8e71fa67b0a9f8666R229-R239) [[8]](diffhunk://#diff-bcd9e3b5cd861ceb06d09dacf75f1a6488a541400c6ab9f8e71fa67b0a9f8666R252-R278) [[9]](diffhunk://#diff-bcd9e3b5cd861ceb06d09dacf75f1a6488a541400c6ab9f8e71fa67b0a9f8666R290-R291) [[10]](diffhunk://#diff-bcd9e3b5cd861ceb06d09dacf75f1a6488a541400c6ab9f8e71fa67b0a9f8666R309-R310) [[11]](diffhunk://#diff-bcd9e3b5cd861ceb06d09dacf75f1a6488a541400c6ab9f8e71fa67b0a9f8666R331-R332) [[12]](diffhunk://#diff-bcd9e3b5cd861ceb06d09dacf75f1a6488a541400c6ab9f8e71fa67b0a9f8666R345-R346) [[13]](diffhunk://#diff-bcd9e3b5cd861ceb06d09dacf75f1a6488a541400c6ab9f8e71fa67b0a9f8666R358-R377) [[14]](diffhunk://#diff-bcd9e3b5cd861ceb06d09dacf75f1a6488a541400c6ab9f8e71fa67b0a9f8666R392-R402)

**UVM Test Infrastructure and Sequences:**

* Added a dedicated sequence, `bmu_valid_in_sequence`, to exercise and verify the new `valid_in` behavior across different scenarios, including toggling `valid_in` and checking output retention. (`sequences/bmu_valid_in_sequence.sv` [sequences/bmu_valid_in_sequence.svR1-R90](diffhunk://#diff-a391ba50d875275f4447ec26ae40b95becb194ac257c6b09ef5ef0c57a9d5463R1-R90))
* Integrated the new sequence into both the regression test (`bmu_regression_test.sv` [[1]](diffhunk://#diff-1100c17ee5a37aebc355a789c70aa9791551f5df6ef6c67d766915d1ddba802eR24) [[2]](diffhunk://#diff-1100c17ee5a37aebc355a789c70aa9791551f5df6ef6c67d766915d1ddba802eR55) [[3]](diffhunk://#diff-1100c17ee5a37aebc355a789c70aa9791551f5df6ef6c67d766915d1ddba802eR91-R92) and as a standalone test (`tests/bmu_valid_in_test.sv` [[4]](diffhunk://#diff-0596ab4957d2e581c47f62bf379dde6d5b2a5ee8f401505de6f913783d5c609eR1-R26).
* Included the sequence and test in the package for compilation and regression. (`components/bmu_pkg.sv` [[1]](diffhunk://#diff-f7b40277d8c77651d0b07ec5d769a5b7ed42c0bb150f1810b014c74a09a6e564R29) [[2]](diffhunk://#diff-f7b40277d8c77651d0b07ec5d769a5b7ed42c0bb150f1810b014c74a09a6e564R60)

**Miscellaneous:**

* Minor cleanup in the scoreboard log message formatting for clarity. (`components/bmu_scoreboard.sv` [components/bmu_scoreboard.svL138-R140](diffhunk://#diff-638b877999dacaca352487cd7f9c2ac579f4caf421d0767e1c062a284ec47372L138-R140))

These changes collectively ensure the BMU's output is consistent with the new requirement for `valid_in` handling and provide comprehensive test coverage for this feature.