### PR TITLE
move the makefile to a separate folder 

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -3,10 +3,10 @@
 #######################################################################################
 
 # Directories
-COMP_DIR = components
-SEQ_DIR = sequences
-TEST_DIR = tests
-RTL_DIR = rtl
+COMP_DIR = ../components
+SEQ_DIR = ../sequences
+TEST_DIR = ../tests
+RTL_DIR = ../rtl
 
 #IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
 TEST_NAME = bmu_regression_test


### PR DESCRIPTION
encapsulate the simulation files in one place

## Summary by Sourcery

Relocate the simulation Makefile into a dedicated sim directory and adjust its directory paths accordingly

Build:
- Move Makefile into the sim folder
- Update COMP_DIR, SEQ_DIR, TEST_DIR, and RTL_DIR variables to reference the correct parent directories